### PR TITLE
Minor syntax change

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -5,7 +5,11 @@ params.search = ""
 params.keywords = ""
 params.help = ""
 
-if(params.help == "") { 
+if( params.help ) { 
+    usage = file("$baseDir/usage.txt")   
+    print usage.text
+    return 
+}
 
 process bootstrap {
 
@@ -315,7 +319,3 @@ process buildHtml {
 
 }
 
-}else {
-    usage = file('usage.txt')   
-    print usage.text
-}


### PR DESCRIPTION
Instead of including all the pipeline code, it is possible to print the help when `params.help` is set and terminate the execution with the `return` keywork. In alternative it's also possible to return a non-zero exit status using `exit <code>` function.
